### PR TITLE
[DOC] add standard GitHub tooling to the project repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/ultra-solo-issue.md
+++ b/.github/ISSUE_TEMPLATE/ultra-solo-issue.md
@@ -1,0 +1,40 @@
+---
+name: Ultra-Solo Issue
+about: Issue standard SPGHICO pour repo en mode Ultra-Solo
+title: ""
+labels: ["prio:P2-important"]
+assignees: []
+---
+
+<!--
+Définir le titre de l’issue puis supprimer ce commentaire.
+
+Formats attendus :
+- [FEATURE] ...
+- [BUG] ...
+- [DOC] ...
+- [QA] ...
+- [REFACTOR] ...
+- [TECH-DEBT] ...
+-->
+
+## Identifiants
+- ProjectCode : PRJ-XXXX
+
+## Contexte
+...
+
+## Objectif
+...
+
+## Critères d’acceptation
+- [ ] ...
+- [ ] ...
+
+## Notes techniques (optionnel)
+...
+
+## Liens
+- Coda (Projet) : {{CODA_URL_OR_NA}}
+- Obsidian (note / ADR) : {{OBSIDIAN_URL_OR_NA}}
+- Pull Request associée :

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+## Résumé
+Décrire brièvement le changement apporté par cette PR.
+
+## Références
+- Closes #<numéro>
+- Coda (Projet) : <url> *(optionnel si déjà porté par l’issue)*
+- Obsidian (note / ADR) : <url> *(optionnel)*
+
+## Type de changement
+- [ ] Feature
+- [ ] Bug
+- [ ] Documentation
+- [ ] QA
+- [ ] Refactor
+- [ ] Tech debt
+- [ ] Chore
+
+## Vérifications minimales
+- [ ] Branche conforme à la convention
+- [ ] PR ouverte vers `main`
+- [ ] Issue liée et cohérente avec le contenu de la PR
+- [ ] Critères d’acceptation vérifiés ou mis à jour si nécessaire
+- [ ] Changement testé localement
+- [ ] Pas de régression identifiée
+
+## Impact
+Préciser s'il y a un impact particulier :
+- technique
+- visuel
+- accessibilité
+- performance
+- déploiement
+
+## Notes
+Informations complémentaires, points d’attention, limites éventuelles.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# PRJ-0013-STFX00-WEB
+
+## Rôle
+
+Repository du projet interne "Site vitrine" de Stack-Flex.
+
+## Statut
+
+- Type : internal-prj
+- Formalisation : `Light`
+- Workflow Git : GitHub Flow
+- Branche stable : `main`
+
+## Liens
+
+- Coda (Projet) : [Lien Table Projects](https://coda.io/d/_dI6Ilo2y-4u/03-1-Projects_suRyl8kb#Projects-New_tuXHYuYO/r13)
+- Obsidian : [Lien dans SPGHICO](obsidian://open?vault=SFx-stack-spghico&file=ops%2Fprojects%2FPRJ-0013-STFX00-WEB%2FREADME)
+
+## Règles
+
+- `main` reste stable et livrable
+- Pas de travail significatif sans issue
+- Chaque PR référence une issue
+- Les micro-tâches vivent dans Super Productivity
+
+## Convention de branches
+
+- `feat/{{ISSUE_ID}}-{{SLUG}}`
+- `fix/{{ISSUE_ID}}-{{SLUG}}`
+- `doc/{{ISSUE_ID}}-{{SLUG}}`
+- `chore/{{ISSUE_ID}}-{{SLUG}}`
+
+---
+
+**🗃️ Historique des versions du README**
+
+| Version | Date       | Auteur     | Description                                                                                     |
+| ------- | ---------- | ---------- | ----------------------------------------------------------------------------------------------- |
+| v1.0    | 2026-04-03 | Stack-Flex | Première version du README utilisé<br>dans un repo de développement<br>inter (ex: site vitrine) |


### PR DESCRIPTION
## Résumé
Ajoute l’outillage GitHub standard au repo `PRJ-0013-STFX00-WEB`.

Cette PR :
- ajoute le template d’issue
- ajoute le template de pull request
- ajoute le `README.md` racine du projet interne Stack-Flex comme point d’entrée documentaire du projet

## Références
- Closes #2

## Type de changement
- [ ] Feature
- [ ] Bug
- [x] Documentation
- [ ] QA
- [ ] Refactor
- [ ] Tech debt
- [x] Chore

## Vérifications minimales
- [x] Branche conforme à la convention
- [x] PR ouverte vers `main`
- [x] Issue liée et cohérente avec le contenu de la PR
- [x] Critères d’acceptation vérifiés ou mis à jour si nécessaire
- [x] Changement testé localement
- [x] Pas de régression identifiée

## Impact
Préciser s'il y a un impact particulier :
- technique : léger, outillage du repo et structuration documentaire
- visuel : aucun
- accessibilité : aucun
- performance : aucun
- déploiement : aucun

## Notes
Cette PR porte sur les éléments versionnés du standard projet :
- template d’issue
- template de pull request
- `README.md` racine du projet

Les labels standard du repo ont été dupliqués séparément côté GitHub et ne font pas partie du diff versionné de cette PR.